### PR TITLE
Destroy dynamo on teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # Twitter Video Bot Lambda
 ## Lambda which replies to video comments with the video URL, deployed via AWS Cloud Development Kit
 
+You will need a Twitter Developer account. Apply here:
+
+https://developer.twitter.com/en/apply-for-access
+
 The app will search for the search string defined in utils
 
 #### 1. Add your Twitter/AWS details
 The project pulls the api keys from AWS SSM param store, add these to the same path as outlined in the
-cdk-twitter-stack.ts param lookups
+cdk-twitter-stack.ts param lookups:
+
+
+Token - '/twitterlambda/accesstoken'
+
+Access token secret - '/twitterlambda/accesstokensecret'
+
+Consumer key - '/twitterlambda/consumerkey'
+
+Consumer key secret - '/twitterlambda/consumersecretkey'
 
 #### 2. Export your aws profile
 
@@ -30,4 +43,10 @@ $  cdk synth
 
 ```sh
 $  cdk deploy
+```
+
+#### 5. Destroy the stack:
+
+```sh
+$  cdk destroy
 ```

--- a/lib/cdk-twitter-stack.ts
+++ b/lib/cdk-twitter-stack.ts
@@ -4,8 +4,9 @@ import lambda = require('@aws-cdk/aws-lambda');
 import ssm = require('@aws-cdk/aws-ssm');
 import iam = require('@aws-cdk/aws-iam');
 import dynamodb = require('@aws-cdk/aws-dynamodb');
-import * as cdk from '@aws-cdk/core';
 import path = require('path');
+import * as cdk from '@aws-cdk/core';
+import {RemovalPolicy} from '@aws-cdk/core';
 import {PolicyStatement} from "@aws-cdk/aws-iam";
 
 export class CdkTwitterStack extends cdk.Stack {
@@ -81,6 +82,7 @@ export class CdkTwitterStack extends cdk.Stack {
 
         new dynamodb.Table(this, dynamoTableName, {
             tableName: dynamoTableName,
+            removalPolicy: RemovalPolicy.DESTROY,
             partitionKey: {name: 'id', type: dynamodb.AttributeType.STRING},
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST
         });


### PR DESCRIPTION
WHAT

Set dynamodb teardown to be destroy
Updated Readme with api key seteup

WHY
I want teardown to be complete. I will add a method to insert an ID to the dynamoDB to stop lambda errors when initially deployed