### PR TITLE
Define search string in params store

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ You will need a Twitter Developer account. Apply here:
 
 https://developer.twitter.com/en/apply-for-access
 
-The app will search for the search string defined in utils
+The app will search for the string set in param store below.
 
-#### 1. Add your Twitter/AWS details:
-The project pulls the api keys from AWS SSM param store, add these to the same path as outlined in the
-cdk-twitter-stack.ts param lookups:
+#### 1. Set up parameters (api keys and search string):
 
+Search String - '/twitterlambda/searchstring'
 
 Token - '/twitterlambda/accesstoken'
 

--- a/lib/cdk-twitter-stack.ts
+++ b/lib/cdk-twitter-stack.ts
@@ -35,6 +35,10 @@ export class CdkTwitterStack extends cdk.Stack {
             parameterName: '/twitterlambda/consumersecretkey',
         }).stringValue;
 
+        const searchString = ssm.StringParameter.fromStringParameterAttributes(this, 'searchString', {
+            parameterName: '/twitterlambda/searchstring',
+        }).stringValue;
+
 
         const twitterLambdaRole = new iam.Role(this, 'twitterLambdaRole', {
             assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com')
@@ -68,6 +72,7 @@ export class CdkTwitterStack extends cdk.Stack {
                 'CONSUMERSECRET': consumerSecret,
                 'ACCESSTOKEN': accessToken,
                 'ACCESSTOKENSECRET': accessTokenSecret,
+                'SEARCHSTRING': searchString,
                 'REGION': region,
                 'PYTHONPATH': pythonPath
             }

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,13 +10,12 @@ consumer_key = os.environ['CONSUMERKEY']
 consumer_secret = os.environ['CONSUMERSECRET']
 access_token = os.environ['ACCESSTOKEN']
 access_token_secret = os.environ['ACCESSTOKENSECRET']
+search_string = os.environ['SEARCHSTRING']
 
 auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
 auth.set_access_token(access_token, access_token_secret)
 
 api = tweepy.API(auth)
-
-search_string = '#search_string'
 
 
 def reply_to_statuses():


### PR DESCRIPTION
**WHAT**
Stack now pulls the search string from param store, and creates an env variable.

Updated readme with new info

**WHY**
I don't want anyone else using my search string